### PR TITLE
Autoloader Fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 	},
 	"autoload": {
 		"psr-0": {
-			"HTTP_Request2" : ""
+			"HTTP_Request2" : "./"
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 	},
 	"autoload": {
 		"psr-0": {
-			"HTTP_Request2" : "./"
+			"HTTP" : "./"
 		}
 	}
 }


### PR DESCRIPTION
This fix will ensure that the `HTTP_Request2` folder is added to the composer `include_paths.php` file
