### PR TITLE
Add include-path section to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,8 @@
 		"psr-0": {
 			"HTTP_Request2" : ""
 		}
-	}
+	},
+	"include-path": [
+		"./"
+	]
 }


### PR DESCRIPTION
If you install HTTP_Request2 through composer, the various require statements will fail because the include_path has not been updated. This pull should fix that.
