### PR TITLE
Allow to run tests with recent dependencies

### DIFF
--- a/tests/Request2Test.php
+++ b/tests/Request2Test.php
@@ -275,7 +275,16 @@ class HTTP_Request2Test extends PHPUnit_Framework_TestCase
 
         $req->setConfig('use_brackets', true)->setUrl('http://php.example.com/');
         $req->getUrl()->setQueryVariable('foo', array('bar', 'baz'));
-        $this->assertEquals('http://php.example.com/?foo[0]=bar&foo[1]=baz', $req->getUrl()->__toString());
+
+        require 'PEAR/Registry.php';
+        $reg = new PEAR_Registry;
+        $pkg = $reg->getPackage('Net_URL2');
+        $version = $pkg->getVersion();
+        if (version_compare($version, '2.1.1', '>=')){
+            $this->assertEquals('http://php.example.com/?foo[]=bar&foo[]=baz', $req->getUrl()->__toString());
+        } else {
+            $this->assertEquals('http://php.example.com/?foo[0]=bar&foo[1]=baz', $req->getUrl()->__toString());
+        }
     }
 
     public function testSetBodyRemovesPostParameters()

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -34,10 +34,7 @@ if ('@' . 'package_version@' == '@package_version@') {
 }
 
 $phpunitVersion = PHPUnit_Runner_Version::id();
-if ($phpunitVersion == '@' . 'package_version@' || !version_compare($phpunitVersion, '3.8', '<=')) {
-    echo "This version of PHPUnit is not supported.";
-    exit(1);
-} elseif (version_compare($phpunitVersion, '3.5.0', '>=')) {
+if (version_compare($phpunitVersion, '3.5.0', '>=')) {
     require_once 'PHPUnit/Autoload.php';
 } else {
     require_once 'PHPUnit/Framework.php';


### PR DESCRIPTION
Those two (ugly) patches allow to run the testsuite with recent PHPUnit (tested with 4.5.0) as well as the [latest Net_URL2 (2.1.1)](https://pear.php.net/bugs/bug.php?id=20519).

There might be a nicer way to test the Net_URL2 version, thanks in advance for any feedback (I’m happy to see this request superseded by a better one, and I’m also happy to improve this one with any advice or pointer to a better solution).
