### PR TITLE
Net_URL2 2.2.0 has switched to classmap autoloader

### DIFF
--- a/HTTP/Request2.php
+++ b/HTTP/Request2.php
@@ -21,7 +21,9 @@
 /**
  * A class representing an URL as per RFC 3986.
  */
-require_once 'Net/URL2.php';
+if (!class_exists('Net_URL2', true)) {
+    require_once 'Net/URL2.php';
+}
 
 /**
  * Exception class for HTTP_Request2 package

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 	},
 	"require"     : {
 		"php"                 : ">=5.2.0",
-		"pear/net_url2"       : ">=2.0.0",
+		"pear/net_url2"       : "~2.2.0",
 		"pear/pear_exception" : "*"
 	},
 	"suggest"     : {


### PR DESCRIPTION
the require_once statement of it has been been made conditional because
the file is not part of the include-path any longer as it has been removed.

The class_exists check triggers the autoloader. In case there is no
autoloader PEAR include path configuration is expected and require_once
works as known with the standard confgured PEAR include path.
