### PR TITLE
Add `extra.branch-alias` setting to `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,37 +1,42 @@
 {
-	"name"        : "pear/http_request2",
-	"description" : "Provides an easy way to perform HTTP requests.",
-	"type"        : "library",
-	"keywords"    : [ "http", "request", "pear", "curl" ],
-	"homepage"    : "http://pear.php.net/package/HTTP_Request2",
-	"license"     : "BSD-3-Clause",
-	"authors"     : [
-		{
-			"name"  : "Alexey Borzov",
-			"email" : "avb@php.net"
-		}
-	],
-	"support": {
-		"issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=HTTP_Request2",
-		"source": "https://github.com/pear/HTTP_Request2"
-	},
-	"require"     : {
-		"php"                 : ">=5.2.0",
-		"pear/net_url2"       : "~2.2.0",
-		"pear/pear_exception" : "*"
-	},
-	"suggest"     : {
-		"ext-fileinfo" : "Adds support for looking up mime-types using finfo.",
-		"ext-zlib"     : "Allows handling gzip compressed responses.",
-		"lib-curl"     : "Allows using cURL as a request backend.",
-		"lib-openssl"  : "Allows handling SSL requests when not using cURL."
-	},
-	"autoload": {
-		"psr-0": {
-			"HTTP_Request2" : ""
-		}
-	},
-	"include-path": [
-		"./"
-	]
+    "name"        : "pear/http_request2",
+    "description" : "Provides an easy way to perform HTTP requests.",
+    "type"        : "library",
+    "keywords"    : [ "http", "request", "pear", "curl" ],
+    "homepage"    : "http://pear.php.net/package/HTTP_Request2",
+    "license"     : "BSD-3-Clause",
+    "authors"     : [
+        {
+            "name"  : "Alexey Borzov",
+            "email" : "avb@php.net"
+        }
+    ],
+    "support": {
+        "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=HTTP_Request2",
+        "source": "https://github.com/pear/HTTP_Request2"
+    },
+    "require"     : {
+        "php"                 : ">=5.2.0",
+        "pear/net_url2"       : "~2.2.0",
+        "pear/pear_exception" : "*"
+    },
+    "suggest"     : {
+        "ext-fileinfo" : "Adds support for looking up mime-types using finfo.",
+        "ext-zlib"     : "Allows handling gzip compressed responses.",
+        "lib-curl"     : "Allows using cURL as a request backend.",
+        "lib-openssl"  : "Allows handling SSL requests when not using cURL."
+    },
+    "autoload": {
+        "psr-0": {
+            "HTTP_Request2" : ""
+        }
+    },
+    "include-path": [
+        "./"
+    ],
+    "extra": {
+        "branch-alias": {
+            "dev-trunk": "2.2-dev"
+        }
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Add `extra.branch-alias` setting to `composer.json` in order to allow install
development versions while respecting semantic versioning.
