### PR TITLE
Clean up dependencies for PEAR and composer specs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     },
     "require"     : {
         "php"                 : ">=5.2.0",
-        "pear/net_url2"       : "~2.2.0",
-        "pear/pear_exception" : "*"
+        "pear/net_url2"       : "^2.2.0",
+        "pear/pear_exception" : "^1.0.0"
     },
     "suggest"     : {
         "ext-fileinfo" : "Adds support for looking up mime-types using finfo.",

--- a/package.xml
+++ b/package.xml
@@ -158,7 +158,7 @@ deflate encodings, redirects, monitoring the request progress with Observers...
       <package>
         <name>Net_URL2</name>
         <channel>pear.php.net</channel>
-        <min>2.1.1</min>
+        <min>2.2.0</min>
       </package>
       <package>
         <name>PEAR</name>


### PR DESCRIPTION
Use semantic versioning for PEAR_Exception dependency.
