### PR TITLE
Support downloading files larger than 4 GiB.

### DIFF
--- a/HTTP/Request2/Response.php
+++ b/HTTP/Request2/Response.php
@@ -639,7 +639,11 @@ class HTTP_Request2_Response
                 'gzinflate() call failed',
                 HTTP_Request2_Exception::DECODE_ERROR
             );
-        } elseif ($dataSize != strlen($unpacked)) {
+
+            // GZIP stores the size of the compressed data in bytes modulo
+            // 2^32. To accommodate large file transfers, apply this to the
+            // observed data size. This allows file downloads above 4 GiB.
+        } elseif ($dataSize != strlen($unpacked) % pow(2, 32)) {
             throw new HTTP_Request2_MessageException(
                 'Data size check failed',
                 HTTP_Request2_Exception::DECODE_ERROR


### PR DESCRIPTION
GZIP metadata contains the uncompressed size of the payload in bytes
modulo 2^32. At decompression, we compare the unpacked size with the value
in GZIP's metadata. To support files larger than 4 GiB, the observed unpacked
size must be restricted by modulo 2^32 as well.