### PR TITLE
Remove usage of set_magic_quotes_runtime (deprecated since 5.3 and removed in 7.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
     - php: "7.1"
     - php: "7.2"
     - php: "7.3"
+    - pnp: "7.4snapshot"
 
 install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
     - php: "7.1"
     - php: "7.2"
     - php: "7.3"
-    - pnp: "7.4snapshot"
+    - php: "7.4snapshot"
 
 install:
   - |

--- a/HTTP/Request2.php
+++ b/HTTP/Request2.php
@@ -926,11 +926,6 @@ class HTTP_Request2 implements SplSubject
         if (empty($this->adapter)) {
             $this->setAdapter($this->getConfig('adapter'));
         }
-        // magic_quotes_runtime may break file uploads and chunked response
-        // processing; see bug #4543. Don't use ini_get() here; see bug #16440.
-        if ($magicQuotes = get_magic_quotes_runtime()) {
-            set_magic_quotes_runtime(false);
-        }
         // force using single byte encoding if mbstring extension overloads
         // strlen() and substr(); see bug #1781, bug #10605
         if (extension_loaded('mbstring') && (2 & ini_get('mbstring.func_overload'))) {
@@ -943,9 +938,6 @@ class HTTP_Request2 implements SplSubject
         } catch (Exception $e) {
         }
         // cleanup in either case (poor man's "finally" clause)
-        if ($magicQuotes) {
-            set_magic_quotes_runtime(true);
-        }
         if (!empty($oldEncoding)) {
             mb_internal_encoding($oldEncoding);
         }


### PR DESCRIPTION
Remove usage of set_magic_quotes_runtime (deprecated since 5.3 and removed in 7.0), similarly remove get_magic_quotes_runtime for similar reasons and tidy-up issue re allowing downloads over 4 GiB as it may cause a Division By Zero exception to be thrown.