### PR TITLE
Fix default reason phrase if header line ends with CRLF

### DIFF
--- a/HTTP/Request2/Response.php
+++ b/HTTP/Request2/Response.php
@@ -218,7 +218,7 @@ class HTTP_Request2_Response
      */
     public function __construct($statusLine, $bodyEncoded = true, $effectiveUrl = null)
     {
-        if (!preg_match('!^HTTP/(\d\.\d) (\d{3})(?: (.+))?!', trim($statusLine), $m)) {
+        if (!preg_match('!^HTTP/(\d\.\d) (\d{3})( [^\r\n]*)?!', $statusLine, $m)) {
             throw new HTTP_Request2_MessageException(
                 "Malformed response: {$statusLine}",
                 HTTP_Request2_Exception::MALFORMED_RESPONSE
@@ -226,7 +226,7 @@ class HTTP_Request2_Response
         }
         $this->version      = $m[1];
         $this->code         = intval($m[2]);
-        $this->reasonPhrase = !empty($m[3]) ? trim($m[3]) : self::getDefaultReasonPhrase($this->code);
+        $this->reasonPhrase = trim($m[3]) ?: self::getDefaultReasonPhrase($this->code);
         $this->bodyEncoded  = (bool)$bodyEncoded;
         $this->effectiveUrl = (string)$effectiveUrl;
     }

--- a/HTTP/Request2/Response.php
+++ b/HTTP/Request2/Response.php
@@ -218,7 +218,7 @@ class HTTP_Request2_Response
      */
     public function __construct($statusLine, $bodyEncoded = true, $effectiveUrl = null)
     {
-        if (!preg_match('!^HTTP/(\d\.\d) (\d{3})(?: (.+))?!', $statusLine, $m)) {
+        if (!preg_match('!^HTTP/(\d\.\d) (\d{3})(?: (.+))?!', trim($statusLine), $m)) {
             throw new HTTP_Request2_MessageException(
                 "Malformed response: {$statusLine}",
                 HTTP_Request2_Exception::MALFORMED_RESPONSE

--- a/tests/Request2/ResponseTest.php
+++ b/tests/Request2/ResponseTest.php
@@ -51,6 +51,11 @@ class HTTP_Request2_ResponseTest extends TestCase
         $this->assertEquals(200, $response4->getStatus());
         $this->assertEquals('OK', $response4->getReasonPhrase());
 
+        $response5 = new HTTP_Request2_Response("HTTP/1.1 200  \r\n");
+        $this->assertEquals('1.1', $response5->getVersion());
+        $this->assertEquals(200, $response5->getStatus());
+        $this->assertEquals('OK', $response5->getReasonPhrase());
+
         new HTTP_Request2_Response('Invalid status line');
     }
 

--- a/tests/Request2/ResponseTest.php
+++ b/tests/Request2/ResponseTest.php
@@ -41,6 +41,16 @@ class HTTP_Request2_ResponseTest extends TestCase
         $this->assertEquals(222, $response2->getStatus());
         $this->assertEquals('Nishtyak!', $response2->getReasonPhrase());
 
+        $response3 = new HTTP_Request2_Response('HTTP/1.1 200 ');
+        $this->assertEquals('1.1', $response3->getVersion());
+        $this->assertEquals(200, $response3->getStatus());
+        $this->assertEquals('OK', $response3->getReasonPhrase());
+
+        $response4 = new HTTP_Request2_Response("HTTP/1.1 200 \r\n");
+        $this->assertEquals('1.1', $response4->getVersion());
+        $this->assertEquals(200, $response4->getStatus());
+        $this->assertEquals('OK', $response4->getReasonPhrase());
+
         new HTTP_Request2_Response('Invalid status line');
     }
 


### PR DESCRIPTION
I discovered that the reason phrase is empty if it's not part of the status line and the Curl adapter is used. In this case the line ends with CRLF (it does not, if the Socket adapter is used), like shown in the tests.